### PR TITLE
make german special chars also work in find panel

### DIFF
--- a/lib/compatible-view.coffee
+++ b/lib/compatible-view.coffee
@@ -18,16 +18,15 @@ class CompatibleView extends View
     @detach()
 
   at: (event) ->
-    debugger
     view = event.targetView()
     if view.editor
         view.editor.insertText('@')
-    else if view
-        view.setText(view.getText()+'@')
+    else if view.model
+        view.model.selections[0]?.editor.insertText("@")
 
   backslash: (event) ->
     view = event.targetView()
     if view.editor
         view.editor.insertText('\\')
     else if view
-        view.setText(view.getText()+'\\')
+        view.model.selections[0]?.editor.insertText("\\")

--- a/lib/compatible-view.coffee
+++ b/lib/compatible-view.coffee
@@ -18,9 +18,16 @@ class CompatibleView extends View
     @detach()
 
   at: (event) ->
-    editor = event.targetView().editor
-    editor.insertText('@') if editor
+    debugger
+    view = event.targetView()
+    if view.editor
+        view.editor.insertText('@')
+    else if view
+        view.setText(view.getText()+'@')
 
   backslash: (event) ->
-    editor = event.targetView().editor
-    editor.insertText('\\') if editor
+    view = event.targetView()
+    if view.editor
+        view.editor.insertText('\\')
+    else if view
+        view.setText(view.getText()+'\\')

--- a/lib/compatible-view.coffee
+++ b/lib/compatible-view.coffee
@@ -28,5 +28,5 @@ class CompatibleView extends View
     view = event.targetView()
     if view.editor
         view.editor.insertText('\\')
-    else if view
+    else if view.model
         view.model.selections[0]?.editor.insertText("\\")


### PR DESCRIPTION
Looks like @ and \ are simply ignored in the find panel. The included patch fixes this, so you can enter both characters in the find panel as you would expect.
