### PR TITLE
fixed the ">" character issue in fr_FR layout

### DIFF
--- a/lib/keymaps/fr_FR.json
+++ b/lib/keymaps/fr_FR.json
@@ -85,6 +85,7 @@
         "shifted": 167
     },
     "226": {
-        "unshifted": 60
+        "unshifted": 60,
+        "shifted": 62
     }
 }


### PR DESCRIPTION
It was not possible to type the ">" character (Shift + <) on the French keyboard layout.
I completed the keyboard mapping file to make it work.
If someone with a French keyboard could confirm it would be great (Atom 0.187.0)

Thanks, 
Uldéric
