### PR TITLE
Fix the mapping for < > on fr_CA layout (wrong keycodes returned by Chro...

### DIFF
--- a/lib/keymaps/fr_CA.json
+++ b/lib/keymaps/fr_CA.json
@@ -83,11 +83,6 @@
         "shifted": 94,
         "alted": 91
     },
-    "220": {
-        "unshifted": 28,
-        "shifted": 62,
-        "alted": 125
-    },
     "221": {
         "alted": 93,
         "unshifted": 29
@@ -96,5 +91,10 @@
         "unshifted": 35,
         "shifted": 124,
         "alted": 92
+    },
+	"229": {
+        "unshifted": 28,
+        "shifted": 62,
+        "alted": 125
     }
 }


### PR DESCRIPTION
Sorry to have not get this right the first time for the fr_CA layout. This PR fixes the key mapping for < > on fr_CA layout (wrong keycodes returned by Chrome, then introduced with the keymap generator ... working in a curly-brackets things these days I didn't noticed it earlier)
