### PR TITLE
Fix < and > key on Spanish keyboards (es_ES)

### DIFF
--- a/lib/keymaps/es_ES.json
+++ b/lib/keymaps/es_ES.json
@@ -75,8 +75,8 @@
         "alted": 91
     },
     "220": {
-        "unshifted": 186,
-        "shifted": 170,
+        "unshifted": 60,
+        "shifted": 62,
         "alted": 92
     },
     "221": {


### PR DESCRIPTION
This key conflicts with º and ª (see #19), but < and > are more useful for programming.
