### PR TITLE
Update fr_FR.json

### DIFF
--- a/lib/keymaps/fr_FR.json
+++ b/lib/keymaps/fr_FR.json
@@ -80,11 +80,7 @@
         "shifted": 176,
         "alted": 93
     },
-    "220": {
-        "unshifted": 42,
-        "shifted": 181,
-        "alted": 124
-    },
+
     "221": {
         "unshifted": 94,
         "shifted": 168,


### PR DESCRIPTION
Solve the [issue 19](https://github.com/andischerer/atom-keyboard-localization/issues/19) for frensh layout. 
As Javascript Keydown makes no difference between "<" and "*" (all code 220) remove it from the package fix the bug.
Atom handles these keys in a different way apparently.
