### PR TITLE
Add Czech qwerty keyboard layout (cs_CZ-qwerty)

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Inside Atom's packages management, click **Settings**, and in the freshly opened
 * Latvian (`lv_LV`)
 * [Portuguese Brazilian (ABNT2)](http://upload.wikimedia.org/wikipedia/commons/thumb/1/17/KB_Portuguese_Brazil.svg/1280px-KB_Portuguese_Brazil.svg.png) (`pt_BR`)
 * Japanese (`ja_JP`)
+* [Czech](https://upload.wikimedia.org/wikipedia/commons/thumb/4/48/Qwerty_cz.svg/1000px-Qwerty_cz.svg.png) (`cs_CZ-qwerty`)
 
 ## Generate your own keymap
 ![](https://raw.github.com/andischerer/atom-keyboard-localization/master/screenshots/keymap-generator.gif)

--- a/lib/keyboard-localization.coffee
+++ b/lib/keyboard-localization.coffee
@@ -28,6 +28,7 @@ KeyboardLocalization =
       type: 'string'
       default: 'de_DE'
       enum: [
+        'cs_CZ-qwerty'
         'da_DK'
         'de_DE-neo'
         'de_DE'

--- a/lib/keymaps/cs_CZ-qwerty.json
+++ b/lib/keymaps/cs_CZ-qwerty.json
@@ -1,0 +1,73 @@
+{
+    "48": {
+        "alted": 41
+    },
+    "49": {
+        "alted": 33
+    },
+    "50": {
+        "alted": 64
+    },
+    "51": {
+        "alted": 35
+    },
+    "52": {
+        "alted": 36
+    },
+    "53": {
+        "alted": 37
+    },
+    "54": {
+        "alted": 94
+    },
+    "55": {
+        "alted": 38
+    },
+    "56": {
+        "alted": 42
+    },
+    "57": {
+        "alted": 40
+    },
+    "186": {
+        "alted": 59,
+        "altshifted": 58
+    },
+    "187": {
+        "alted": 61,
+        "altshifted": 43
+    },
+    "188": {
+        "alted": 60
+    },
+    "189": {
+        "alted": 45,
+        "altshifted": 95
+    },
+    "190": {
+        "alted": 62
+    },
+    "191": {
+        "alted": 47,
+        "altshifted": 63
+    },
+    "192": {
+        "alted": 96,
+        "altshifted": 126
+    },
+    "219": {
+        "alted": 91,
+        "altshifted": 123
+    },
+    "220": {
+        "alted": 92,
+        "altshifted": 124
+    },
+    "221": {
+        "alted": 93,
+        "altshifted": 125
+    },
+    "222": {
+        "alted": 164
+    }
+}


### PR DESCRIPTION
This is the Czech qwerty keyboard layout in this pull request. It is strictly modeled on Windows Czech qwerty keyboard (there is also Czech qwertz keyboard, but many important characters like [, ], {, or } are missing on it, so it is useless for programmers). I tested it as a json file on my windows notebook and works quite well :), didn't try it as a whole module. 

The layout of Czech qwerty keyboard is like layout of Czech Qwertz keyboard except y<->z (see picture in README.md), but after pressing AltGr on Qwerty layout you can type some characters like on US layout.

As I mentioned, this is windows layout. Unfortunately on Linux, the layout is slightly different (very close to Mac layout). I will try it in foreseeable future on Linux and depending on the result I will decide what to do. 

In the end I want to acknowledge your effort. I have been using Atom for a long time on Mac but it was unusable on Windows. Now with your plugin I am able to use it on Windows. Thanks.
