### PR TITLE
Fixes #65. Replace `util._extend` with `jQuery.extend`.

### DIFF
--- a/lib/views/keymap-generator-view.coffee
+++ b/lib/views/keymap-generator-view.coffee
@@ -1,5 +1,5 @@
 {Disposable} = require 'atom'
-{ScrollView, TextEditorView} = require 'atom-space-pen-views'
+{ScrollView, TextEditorView, $} = require 'atom-space-pen-views'
 util = require 'util'
 
 KeyMapper = require '../key-mapper'
@@ -82,7 +82,7 @@ class KeymapGeneratorView extends ScrollView
     @keyDownView.clear()
     @keyPressView.clear()
 
-    originalEvent = util._extend({}, event.originalEvent)
+    originalEvent = $.extend({}, event.originalEvent)
     @modifierStateHandler.handleKeyEvent(originalEvent)
     modifierState = @modifierStateHandler.getState()
     @updateModifiers(modifierState)

--- a/lib/views/keymap-generator-view.coffee
+++ b/lib/views/keymap-generator-view.coffee
@@ -1,5 +1,5 @@
 {Disposable} = require 'atom'
-{ScrollView, TextEditorView} = require 'atom-space-pen-views'
+{ScrollView, TextEditorView, $} = require 'atom-space-pen-views'
 util = require 'util'
 
 KeyMapper = require '../key-mapper'
@@ -82,18 +82,18 @@ class KeymapGeneratorView extends ScrollView
     @keyDownView.clear()
     @keyPressView.clear()
 
-    originalEvent = util._extend({}, event.originalEvent)
+    originalEvent = $.extend({}, event.originalEvent)
     @modifierStateHandler.handleKeyEvent(originalEvent)
     modifierState = @modifierStateHandler.getState()
     @updateModifiers(modifierState)
     @keyDownView.setKey(originalEvent, modifierState)
 
   onKeyPress: (event) ->
-    originalEvent = util._extend({}, event.originalEvent)
+    originalEvent = $.extend({}, event.originalEvent)
     @keyPressView.setKey(originalEvent, @modifierStateHandler.getState())
 
   onKeyUp: (event) ->
-    originalEvent = util._extend({}, event.originalEvent)
+    originalEvent = $.extend({}, event.originalEvent)
     @modifierStateHandler.handleKeyEvent(originalEvent)
     @addMapping()
 


### PR DESCRIPTION
Since `util._extend()` seems to fail when try to copy the `event.originalEvent`. I replaced it with `jQuery.extend()` that has same behaviour and works just fine.
