### PR TITLE
Add Estonian keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Inside Atom's packages management, click **Settings**, and in the freshly opened
 * [Portuguese Brazilian (ABNT2)](http://upload.wikimedia.org/wikipedia/commons/thumb/1/17/KB_Portuguese_Brazil.svg/1280px-KB_Portuguese_Brazil.svg.png) (`pt_BR`)
 * Japanese (`ja_JP`)
 * [Czech](https://upload.wikimedia.org/wikipedia/commons/thumb/4/48/Qwerty_cz.svg/1000px-Qwerty_cz.svg.png) (`cs_CZ-qwerty`)
-* [Estonian](https://upload.wikimedia.org/wikipedia/commons/thumb/9/9e/KB_Estonian.svg/900px-KB_Estonian.svg.png) (`et_EE`)
+* [Estonian](https://upload.wikimedia.org/wikipedia/commons/thumb/9/9e/KB_Estonian.svg/900px-KB_Estonian.svg.png) (`et_EE`) - untested
 
 ## Generate your own keymap
 ![](https://raw.github.com/andischerer/atom-keyboard-localization/master/screenshots/keymap-generator.gif)

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Inside Atom's packages management, click **Settings**, and in the freshly opened
 * [Portuguese Brazilian (ABNT2)](http://upload.wikimedia.org/wikipedia/commons/thumb/1/17/KB_Portuguese_Brazil.svg/1280px-KB_Portuguese_Brazil.svg.png) (`pt_BR`)
 * Japanese (`ja_JP`)
 * [Czech](https://upload.wikimedia.org/wikipedia/commons/thumb/4/48/Qwerty_cz.svg/1000px-Qwerty_cz.svg.png) (`cs_CZ-qwerty`)
+* [Estonian](https://upload.wikimedia.org/wikipedia/commons/thumb/9/9e/KB_Estonian.svg/900px-KB_Estonian.svg.png) (`et_EE`)
 
 ## Generate your own keymap
 ![](https://raw.github.com/andischerer/atom-keyboard-localization/master/screenshots/keymap-generator.gif)

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Inside Atom's packages management, click **Settings**, and in the freshly opened
 * [Portuguese Brazilian (ABNT2)](http://upload.wikimedia.org/wikipedia/commons/thumb/1/17/KB_Portuguese_Brazil.svg/1280px-KB_Portuguese_Brazil.svg.png) (`pt_BR`)
 * Japanese (`ja_JP`)
 * [Czech](https://upload.wikimedia.org/wikipedia/commons/thumb/4/48/Qwerty_cz.svg/1000px-Qwerty_cz.svg.png) (`cs_CZ-qwerty`)
-* [Estonian](https://upload.wikimedia.org/wikipedia/commons/thumb/9/9e/KB_Estonian.svg/900px-KB_Estonian.svg.png) (`et_EE`) - untested
+* [Estonian](https://upload.wikimedia.org/wikipedia/commons/thumb/9/9e/KB_Estonian.svg/900px-KB_Estonian.svg.png) (`et_EE`)
 
 ## Generate your own keymap
 ![](https://raw.github.com/andischerer/atom-keyboard-localization/master/screenshots/keymap-generator.gif)

--- a/lib/keyboard-localization.coffee
+++ b/lib/keyboard-localization.coffee
@@ -35,6 +35,7 @@ KeyboardLocalization =
         'de_DE'
         'es_ES'
         'es_LA'
+        'et_EE'
         'fr_BE'
         'fr_CH'
         'fr_FR'

--- a/lib/keymaps/et_EE.json
+++ b/lib/keymaps/et_EE.json
@@ -1,0 +1,105 @@
+{
+    "48": {
+        "shifted": 61,
+        "alted": 125,
+        "unshifted": 125
+    },
+    "49": {
+        "shifted": 33
+    },
+    "50": {
+        "shifted": 34,
+        "alted": 64,
+        "unshifted": 64
+    },
+    "51": {
+        "shifted": 35,
+        "alted": 163,
+        "unshifted": 163
+    },
+    "52": {
+        "shifted": 164,
+        "alted": 36,
+        "unshifted": 36
+    },
+    "53": {
+        "shifted": 37,
+        "alted": 8364,
+        "unshifted": 8364
+    },
+    "54": {
+        "shifted": 38
+    },
+    "55": {
+        "shifted": 47,
+        "alted": 123,
+        "unshifted": 123
+    },
+    "56": {
+        "shifted": 40,
+        "alted": 91,
+        "unshifted": 91
+    },
+    "57": {
+        "shifted": 41,
+        "alted": 93,
+        "unshifted": 93
+    },
+    "69": {
+        "alted": 8364,
+        "unshifted": 8364
+    },
+    "83": {
+        "unshifted": 353,
+        "shifted": 352
+    },
+    "90": {
+        "unshifted": 382,
+        "shifted": 381
+    },
+    "187": {
+        "accent": true,
+        "shifted": 96,
+        "unshifted": 180
+    },
+    "188": {
+        "unshifted": 44,
+        "shifted": 59
+    },
+    "189": {
+        "shifted": 63,
+        "alted": 92,
+        "unshifted": 92
+    },
+    "190": {
+        "unshifted": 127,
+        "shifted": 58
+    },
+    "191": {
+        "accent": true,
+        "alted": 94,
+        "unshifted": 94,
+        "shifted": 196
+    },
+    "219": {
+        "alted": 167,
+        "unshifted": 167
+    },
+    "220": {
+        "alted": 189,
+        "shifted": 42,
+        "unshifted": 189,
+    },
+    "221": {
+        "unshifted": 45,
+        "shifted": 95
+    },
+    "222": {
+        "shifted": 126,
+        "unshifted": 711
+    },
+    "226": {
+        "unshifted": 124,
+        "shifted": 62
+    }
+}

--- a/lib/keymaps/et_EE.json
+++ b/lib/keymaps/et_EE.json
@@ -88,7 +88,7 @@
     "220": {
         "alted": 189,
         "shifted": 42,
-        "unshifted": 189,
+        "unshifted": 189
     },
     "221": {
         "unshifted": 45,


### PR DESCRIPTION
Found this project because ctrl + alt + _the key to the right of 0_ stopped producing `\`, this now among other things works.

What doesn't work is ctrl + alt + s producing š, it opens spec suite instead :cry:
