### PR TITLE
Fix curly braces for it_IT keyboards

### DIFF
--- a/lib/keymaps/it_IT.json
+++ b/lib/keymaps/it_IT.json
@@ -110,11 +110,13 @@
     },
     "186": {
         "alted": 91,
+        "altshifted": 123,
         "unshifted": 232,
         "shifted": 233
     },
     "187": {
         "alted": 93,
+        "altshifted": 125,
         "unshifted": 43,
         "shifted": 42
     },


### PR DESCRIPTION
This is a fix for issue https://github.com/andischerer/atom-keyboard-localization/issues/76, so the Italians don't need to fix it by themselves by providing their own config file.
