### PR TITLE
Fi fi fixes

### DIFF
--- a/lib/keymaps/fi_FI.json
+++ b/lib/keymaps/fi_FI.json
@@ -73,7 +73,8 @@
     },
     "220": {
         "shifted": 189,
-        "unshifted": 167
+        "unshifted": 167,
+        "alted": 124
     },
     "221": {
         "shifted": 197,

--- a/lib/keymaps/fi_FI.json
+++ b/lib/keymaps/fi_FI.json
@@ -69,7 +69,8 @@
     },
     "192": {
         "shifted": 214,
-        "unshifted": 246
+        "unshifted": 246,
+        "alted": 248
     },
     "220": {
         "shifted": 189,
@@ -83,7 +84,8 @@
     },
     "222": {
         "shifted": 196,
-        "unshifted": 228
+        "unshifted": 228,
+        "alted": 230
     },
     "226": {
         "shifted": 62,


### PR DESCRIPTION
Added missing:
altgr+< makes |  (used to make § for no apparent reason?)
altgr+ö makes ø,
altgr+ä makes æ
