### PR TITLE
Fix < and >

### DIFF
--- a/lib/keymaps/fr_FR.json
+++ b/lib/keymaps/fr_FR.json
@@ -94,7 +94,7 @@
         "unshifted": 33,
         "shifted": 167
     },
-    "226": {
+    "220": {
         "unshifted": 60,
         "shifted": 62
     }


### PR DESCRIPTION
This PR fixes indentation with `<` and `>` for fr_Fr keymap.

Steps to reproduce original bug:
- use fr_FR layout and open keybinding resolver
- open text file
- press `<` and see keybinding resolving to `\`
- open keymap generator
- press `<` in `capture key-events` field and see:

```
{
    "220": {
        "unshifted": 60
    }
}
```
- go back to text file
- press `<` and see that keybinding is correctly resolved to `<`
